### PR TITLE
Fix description: build-platform is only used for 'build' jobs

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -17,7 +17,7 @@ configuration:
         default: 'build'
     build-platform:
         type: string
-        description: "The factory build platform. Defaults to 'opensource_centos7'."
+        description: "The factory build platform, only used for build jobs. Defaults to 'opensource_centos7'."
         default: 'opensource_centos7'
 
   additionalProperties: false


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
