### PR TITLE
Set job-run success only for the last job step.

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -7,6 +7,7 @@ set -eo pipefail
 
 PIPELINE="$BUILDKITE_PLUGIN_FACTORY_REPORTER_PIPELINE_ID"
 JOB_TYPE="$BUILDKITE_PLUGIN_FACTORY_REPORTER_JOB_TYPE"
+LAST_STEP="$BUILDKITE_PLUGIN_FACTORY_REPORTER_LAST_STEP"
 
 if [[ $SKIP_BUILDKITE_PLUGINS == "true" ]]; then
     echo "SKIP_BUILDKITE_PLUGINS is set. Skipping factory reporter"
@@ -39,6 +40,9 @@ if [[ -z $FACTORY_COMMAND ]]; then
 fi
 echo "Using factory command: $FACTORY_COMMAND"
 
+# TODO: remove
+echo "LAST_STEP: $LAST_STEP"
+
 if [[ -n $BUILDKITE_COMMAND_EXIT_STATUS ]] && (( $BUILDKITE_COMMAND_EXIT_STATUS != 0 )); then
   echo "Build #$BUILDKITE_BUILD_NUMBER failed, setting job run status to failure"
   $FACTORY_COMMAND update-buildkite-job-run $START_SECONDS $PIPELINE "failure"
@@ -48,6 +52,10 @@ if [[ -n $BUILDKITE_COMMAND_EXIT_STATUS ]] && (( $BUILDKITE_COMMAND_EXIT_STATUS 
     $FACTORY_COMMAND update-build-status $PIPELINE failure "Build failed"
   fi
 else
-  echo "Build #$BUILDKITE_BUILD_NUMBER succeeded, setting job run status to success"
-  $FACTORY_COMMAND update-buildkite-job-run $START_SECONDS $PIPELINE "success"
+  if [[ $LAST_STEP == "true" ]]; then
+    echo "Last step of build #$BUILDKITE_BUILD_NUMBER succeeded, setting job run status to success"
+    $FACTORY_COMMAND update-buildkite-job-run $START_SECONDS $PIPELINE "success"
+  else
+    echo "Non-final step in build #$BUILDKITE_BUILD_NUMBER succeeded, skipping job run status update"
+  fi
 fi


### PR DESCRIPTION
This is to prepare for reporting build status from the plugin instead of each individual pipeline.
