### PR TITLE
The step key is needed to retrieve the step outcome.

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -40,12 +40,20 @@ if [[ -z $FACTORY_COMMAND ]]; then
 fi
 echo "Using factory command: $FACTORY_COMMAND"
 
+step_key=$(buildkite-agent step get "key" || echo "")
+echo "Buildkite step key: '$step_key'"
+step_outcome=$(buildkite-agent step get "outcome" --step "$step_key" || echo "")
+echo "Buildkite step outcome: '$step_outcome'"
+
 if [[ -n $BUILDKITE_COMMAND_EXIT_STATUS ]] && (( $BUILDKITE_COMMAND_EXIT_STATUS != 0 )); then
-  # Don't report failure if the step soft-failed (exit code 99)
-  step_outcome=$(buildkite-agent step get outcome || echo "")
-  echo "Step outcome: '$step_outcome'"
+  # Don't report status if the step soft-failed.
   if [[ "$step_outcome" == "soft_failed" ]]; then
-    echo "Step soft-failed, skipping job run status update"
+    if [[ $LAST_STEP == "true" ]]; then
+      # Soft-failed should never be used on the last job step
+      echo "Error: Last step '$step_key' soft-failed, this should never happen" >&2
+      exit 1
+    fi
+    echo "Step '$step_key' soft-failed, skipping job run status update"
     exit 0
   fi
 

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -212,25 +212,50 @@ run_failing_build_job() {
 }
 
 
-@test "Skip reporting is step soft failed" {
+@test "Skip reporting for soft-failed step" {
   export BUILDKITE_PLUGIN_FACTORY_REPORTER_PIPELINE_ID=123456
   export BUILDKITE_PULL_REQUEST=false
   export BUILDKITE_COMMAND_EXIT_STATUS=1
   export BUILDKITE_BUILD_NUMBER=222
+  export BUILDKITE_PLUGIN_FACTORY_REPORTER_LAST_STEP=false
 
   stub buildkite-agent \
     "meta-data get start-seconds : echo 1234567890" \
-    "meta-data get factory-command : echo factory-command"\
-    "step get outcome : echo soft_failed"
+    "meta-data get factory-command : echo factory-command" \
+    "step get key : echo step1" \
+    "step get outcome --step step1 : echo soft_failed"
 
   run "$BATS_TEST_DIRNAME/../hooks/post-command"
 
   assert_success
 
-  assert_line "Step soft-failed, skipping job run status update"
+  assert_line "Step 'step1' soft-failed, skipping job run status update"
 
   refute_line --partial "factory-command update-buildkite-job-run"
-  refute_line --partial "factory-command update-build-status"
+
+  unstub buildkite-agent || true
+}
+
+@test "Fail if last step is soft-failed" {
+  export BUILDKITE_PLUGIN_FACTORY_REPORTER_PIPELINE_ID=123456
+  export BUILDKITE_PULL_REQUEST=false
+  export BUILDKITE_COMMAND_EXIT_STATUS=1
+  export BUILDKITE_BUILD_NUMBER=222
+  export BUILDKITE_PLUGIN_FACTORY_REPORTER_LAST_STEP=true
+
+  stub buildkite-agent \
+    "meta-data get start-seconds : echo 1234567890" \
+    "meta-data get factory-command : echo factory-command" \
+    "step get key : echo step1" \
+    "step get outcome --step step1 : echo soft_failed"
+
+  run "$BATS_TEST_DIRNAME/../hooks/post-command"
+
+  assert_failure
+
+  assert_line "Error: Last step 'step1' soft-failed, this should never happen"
+
+  refute_line "Step 'step1' soft-failed, skipping job run status update"
 
   unstub buildkite-agent || true
 }


### PR DESCRIPTION
See https://buildkite.com/docs/agent/v3/cli-step#getting-the-outcome-of-a-step