### PR TITLE
fix: update to use BUILDKITE_STEP_ID instead of BUILDKITE_STEP_KEY

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -40,7 +40,8 @@ if [[ -z $FACTORY_COMMAND ]]; then
 fi
 echo "Using factory command: $FACTORY_COMMAND"
 
-step_outcome=$(buildkite-agent step get "outcome" --step "$BUILDKITE_STEP_KEY" || echo "")
+echo "Reporting status for build '#$BUILDKITE_BUILD_NUMBER' at step '$BUILDKITE_STEP_ID'"
+step_outcome=$(buildkite-agent step get "outcome" --step "$BUILDKITE_STEP_ID" || echo "")
 echo "Buildkite step outcome: '$step_outcome'"
 
 if [[ -n $BUILDKITE_COMMAND_EXIT_STATUS ]] && (( $BUILDKITE_COMMAND_EXIT_STATUS != 0 )); then
@@ -48,10 +49,10 @@ if [[ -n $BUILDKITE_COMMAND_EXIT_STATUS ]] && (( $BUILDKITE_COMMAND_EXIT_STATUS 
   if [[ "$step_outcome" == "soft_failed" ]]; then
     if [[ $LAST_STEP == "true" ]]; then
       # Soft-failed should never be used on the last job step
-      echo "Error: Last step '$BUILDKITE_STEP_KEY' soft-failed, this should never happen" >&2
+      echo "Error: Last step '$BUILDKITE_STEP_ID' soft-failed, this should never happen" >&2
       exit 1
     fi
-    echo "Step '$BUILDKITE_STEP_KEY' soft-failed, skipping job run status update"
+    echo "Step '$BUILDKITE_STEP_ID' soft-failed, skipping job run status update"
     exit 0
   fi
 

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -1,4 +1,8 @@
 #!/usr/bin/env bats
+#
+# Tests require redefining shell variables
+# shellcheck disable=SC2030,SC2031
+
 
 load "$BATS_PLUGIN_PATH/bats-assert/load.bash"
 load "$BATS_PLUGIN_PATH/bats-mock/stub.bash"
@@ -218,7 +222,7 @@ run_failing_build_job() {
   export BUILDKITE_COMMAND_EXIT_STATUS=1
   export BUILDKITE_BUILD_NUMBER=222
   export BUILDKITE_PLUGIN_FACTORY_REPORTER_LAST_STEP=false
-  export BUILDKITE_STEP_KEY=abc456
+  export BUILDKITE_STEP_ID=abc456
 
   stub buildkite-agent \
     "meta-data get start-seconds : echo 1234567890" \
@@ -242,7 +246,7 @@ run_failing_build_job() {
   export BUILDKITE_COMMAND_EXIT_STATUS=1
   export BUILDKITE_BUILD_NUMBER=222
   export BUILDKITE_PLUGIN_FACTORY_REPORTER_LAST_STEP=true
-  export BUILDKITE_STEP_KEY=abc456
+  export BUILDKITE_STEP_ID=abc456
 
   stub buildkite-agent \
     "meta-data get start-seconds : echo 1234567890" \


### PR DESCRIPTION
### What

- Refactor post-command hook to use BUILDKITE_STEP_ID instead of the deprecated BUILDKITE_STEP_KEY variable
- Update related tests to reflect the change from BUILDKITE_STEP_KEY to BUILDKITE_STEP_ID