### PR TITLE
Use ignore-fail config parameter to skip failure reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ steps:
     plugins:
       - ./.buildkite/plugins/factory-reporter:
           pipeline-id: 123
-          first-step: true
+          last-step: true
+          job-type: build
+
 ```
 
 ## Configuration
@@ -20,13 +22,18 @@ steps:
 
 The id of the pipeline
 
-### `first-step` (Required, boolean)
+### `last-step` (Required, boolean)
 
-Set to true if this is the first step in the pipeline
+Set to true if this is the last step in the pipeline
+
 
 ### `job-type` (Optional, string)
 
 The type of job. Defaults to `build`.
+
+### 'ignore-fail' (Optional, boolean)
+
+Set to true to skip reporting failure to factory for this step. Defaults to `false`.
 
 ### `build-platform` (Optional, string)
 

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -8,6 +8,7 @@ set -eo pipefail
 PIPELINE="$BUILDKITE_PLUGIN_FACTORY_REPORTER_PIPELINE_ID"
 JOB_TYPE="$BUILDKITE_PLUGIN_FACTORY_REPORTER_JOB_TYPE"
 LAST_STEP="$BUILDKITE_PLUGIN_FACTORY_REPORTER_LAST_STEP"
+IGNORE_FAIL="${BUILDKITE_PLUGIN_FACTORY_REPORTER_IGNORE_FAIL:-false}"
 
 if [[ $SKIP_BUILDKITE_PLUGINS == "true" ]]; then
     echo "SKIP_BUILDKITE_PLUGINS is set. Skipping factory reporter"
@@ -40,19 +41,15 @@ if [[ -z $FACTORY_COMMAND ]]; then
 fi
 echo "Using factory command: $FACTORY_COMMAND"
 
-echo "Reporting status for build '#$BUILDKITE_BUILD_NUMBER' at step '$BUILDKITE_STEP_ID'"
-step_outcome=$(buildkite-agent step get "outcome" --step "$BUILDKITE_STEP_ID" || echo "")
-echo "Buildkite step outcome: '$step_outcome'"
 
 if [[ -n $BUILDKITE_COMMAND_EXIT_STATUS ]] && (( $BUILDKITE_COMMAND_EXIT_STATUS != 0 )); then
-  # Don't report status if the step soft-failed.
-  if [[ "$step_outcome" == "soft_failed" ]]; then
+  if [[ $IGNORE_FAIL == "true" ]]; then
     if [[ $LAST_STEP == "true" ]]; then
-      # Soft-failed should never be used on the last job step
-      echo "Error: Last step '$BUILDKITE_STEP_ID' soft-failed, this should never happen" >&2
+      # ignore-fail should never be used on the last job step
+      echo "Error: IGNORE_FAIL was true for last step '$BUILDKITE_STEP_ID', this is not allowed" >&2
       exit 1
     fi
-    echo "Step '$BUILDKITE_STEP_ID' soft-failed, skipping job run status update"
+    echo "IGNORE_FAIL is true for step '$BUILDKITE_STEP_ID', skipping failure update"
     exit 0
   fi
 


### PR DESCRIPTION
## What
Use a config parameter for ignoring failures

## Why
This is simpler and more flexible than relying on buildkite's soft_failed step outcome.
