### PR TITLE
Fix tmpdir path

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 #
 # This script is run after the command has completed, and updates the job run status in factory.

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright Vespa.ai. Licensed under the terms of the Apache 2.0 license. See LICENSE in the project root.
 
 set -eo pipefail

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -37,7 +37,7 @@ EOF
 setup() {
   # Create mock factory-command in the PATH.
   # This is more convenient than using a stub that is called multiple times.
-  local tmpdir="${BATS_TEST_TMPDIR/bin}"
+  local tmpdir="$BATS_TEST_TMPDIR/bin"
   mkdir -p "$tmpdir"
   create_mock_factory_command "$tmpdir"
   export PATH="$tmpdir:$PATH"

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -18,7 +18,7 @@ setup_file() {
 
 setup() {
   # Create mock executable commands in the PATH
-  local tmpdir="${BATS_TEST_TMPDIR/bin}"
+  local tmpdir="$BATS_TEST_TMPDIR/bin"
   mkdir -p "$tmpdir"
   create_mock_factory_command "$tmpdir"
   export PATH="$tmpdir:$PATH"


### PR DESCRIPTION
## What
Fix setting of tmpdir and use portable bash shebang

## Why
Make bats tests run without issues on mac. They used to, but failed now after a lot of updates on my mac since last time I tried.